### PR TITLE
Cascade delete rows from tables when referenced rows are deleted

### DIFF
--- a/init_db
+++ b/init_db
@@ -16,7 +16,7 @@ CREATE TABLE Availability (
     EndDate DATETIME DEFAULT CURRENT_TIMESTAMP,
     Price INT NOT NULL,
     PRIMARY KEY (ListingID, StartDate, EndDate),
-    FOREIGN KEY (ListingID) REFERENCES Listing(ListingID)
+    FOREIGN KEY (ListingID) REFERENCES Listing(ListingID) ON DELETE CASCADE
 );
 
 CREATE TABLE Amenities (
@@ -27,7 +27,7 @@ CREATE TABLE Amenities (
     Beds INT DEFAULT 0,
     Kitchen INT DEFAULT 0,
     ParkingSpots INT DEFAULT 0,
-    FOREIGN KEY (ListingID) REFERENCES  Listing(ListingID)
+    FOREIGN KEY (ListingID) REFERENCES  Listing(ListingID) ON DELETE CASCADE
 );
 
 CREATE TABLE Address (
@@ -47,20 +47,20 @@ CREATE TABLE User (
 
 CREATE TABLE Host (
     SIN VARCHAR(20) NOT NULL,
-    FOREIGN KEY (SIN) REFERENCES User(SIN)
+    FOREIGN KEY (SIN) REFERENCES User(SIN) ON DELETE CASCADE
 );
 
 CREATE TABLE Renter (
     SIN VARCHAR(20) NOT NULL,
     CreditCardNumber CHAR(16),
-    FOREIGN KEY (SIN) REFERENCES User(SIN)
+    FOREIGN KEY (SIN) REFERENCES User(SIN) ON DELETE CASCADE
 );
  
 CREATE TABLE LocatedAt (
     ListingID CHAR(20) NOT NULL,
     Country VARCHAR(20) NOT NULL,
     PostalCode VARCHAR(10) NOT NULL,
-    FOREIGN KEY (ListingID) REFERENCES Listing(ListingID),
+    FOREIGN KEY (ListingID) REFERENCES Listing(ListingID) ON DELETE CASCADE,
     FOREIGN KEY (Country, PostalCode)
 REFERENCES Address(Country, PostalCode)
 );
@@ -70,15 +70,15 @@ CREATE TABLE ResidesAt (
     SIN VARCHAR(20) NOT NULL,
     Country VARCHAR(20) NOT NULL,
     PostalCode VARCHAR(20) NOT NULL,
-    FOREIGN KEY (SIN) REFERENCES User(SIN),
+    FOREIGN KEY (SIN) REFERENCES User(SIN) ON DELETE CASCADE,
     FOREIGN KEY (Country, PostalCode) REFERENCES Address(Country, PostalCode)
 );
 
 CREATE TABLE HostedBy (
     ListingID Char(20) NOT NULL,
     SIN VARCHAR(20) NOT NULL,
-    FOREIGN KEY (ListingID) REFERENCES Listing(ListingID),
-    FOREIGN KEY (SIN) REFERENCES Host(SIN)
+    FOREIGN KEY (ListingID) REFERENCES Listing(ListingID) ON DELETE CASCADE,
+    FOREIGN KEY (SIN) REFERENCES Host(SIN) ON DELETE CASCADE
 );
 
 CREATE TABLE Booking (
@@ -87,8 +87,8 @@ CREATE TABLE Booking (
     EndDate DATETIME NOT NULL,
     SIN VARCHAR(20) NOT NULL,
     Cancelled BIT(1) DEFAULT 0,
-    FOREIGN KEY (ListingID, StartDate, EndDate) REFERENCES Availability(ListingID, StartDate, EndDate),
-    FOREIGN KEY (SIN) REFERENCES Renter(SIN)
+    FOREIGN KEY (ListingID, StartDate, EndDate) REFERENCES Availability(ListingID, StartDate, EndDate) ON DELETE CASCADE,
+    FOREIGN KEY (SIN) REFERENCES Renter(SIN) ON DELETE CASCADE
 );
 
 
@@ -97,7 +97,7 @@ CREATE TABLE ListingReview (
     SIN VARCHAR(20) NOT NULL,
     Comment VARCHAR(250),
     Rating INT NOT NULL,
-    FOREIGN KEY (ListingID) REFERENCES Listing(ListingID),
+    FOREIGN KEY (ListingID) REFERENCES Listing(ListingID) ON DELETE CASCADE,
     FOREIGN KEY (SIN) REFERENCES Renter(SIN)
 );
 
@@ -107,7 +107,7 @@ CREATE TABLE HostReview (
     RenterSIN VARCHAR(20) NOT NULL,
     Comment VARCHAR(250),
     Rating INT NOT NULL,
-    FOREIGN KEY (HostSIN) REFERENCES Host(SIN),
+    FOREIGN KEY (HostSIN) REFERENCES Host(SIN) ON DELETE CASCADE,
     FOREIGN KEY (RenterSIN) REFERENCES Renter(SIN)
 );
 
@@ -116,6 +116,6 @@ CREATE TABLE RenterReview (
     RenterSIN VARCHAR(20) NOT NULL,
     Comment VARCHAR(250),
     Rating INTEGER NOT NULL,
-    FOREIGN KEY (RenterSIN) REFERENCES Renter(SIN),
+    FOREIGN KEY (RenterSIN) REFERENCES Renter(SIN) ON DELETE CASCADE,
     FOREIGN KEY (HostSIN) REFERENCES Host(SIN)
 );


### PR DESCRIPTION
These changes allow the database to automatically delete rows when referenced rows in other tables are deleted.
For example, if a Listing is deleted, then the corresponding rows in Availability, LocatedAt, Amenities, Bookings, and ListingReview will automatically be deleted as well.